### PR TITLE
Add websocket integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -56,6 +56,31 @@ dependencies = [
  "tokio-util",
  "tracing",
  "zstd",
+]
+
+[[package]]
+name = "actix-http-test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061d27c2a6fea968fdaca0961ff429d23a4ec878c4f68f5d08626663ade69c80"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "awc",
+ "bytes",
+ "futures-core",
+ "http 0.2.12",
+ "log",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "slab",
+ "socket2",
+ "tokio",
 ]
 
 [[package]]
@@ -76,7 +101,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -89,6 +114,7 @@ version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
+ "actix-macros",
  "futures-core",
  "tokio",
 ]
@@ -118,6 +144,48 @@ checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "actix-test"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439022b5a7b5dac10798465029a9566e8e0cca7a6014541ed277b695691fac5f"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-http-test",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "awc",
+ "futures-core",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
+
+[[package]]
+name = "actix-tls"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac453898d866cdbecdbc2334fe1738c747b4eba14a677261f2b768ba05329389"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "impl-more",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -264,6 +332,39 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "awc"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e76d68b4f02400c2f9110437f254873e8f265b35ea87352f142bc7c8e878115a"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "base64",
+ "bytes",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
 
 [[package]]
 name = "backtrace"
@@ -549,6 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -594,7 +696,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -619,6 +721,17 @@ name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1485,9 +1598,11 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vpscheck"
 version = "0.1.0"
 dependencies = [
+ "actix-test",
  "actix-web",
  "actix-ws",
  "anyhow",
+ "awc",
  "futures-util",
  "procfs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 sysinfo = { version = "0.35" }
 procfs  = "0.17.0"          # 与 sysinfo MSRV 相同
 anyhow  = "1.0.98"
+
+[dev-dependencies]
+actix-test = "0.1"
+awc = "3"

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,5 +1,8 @@
-use actix_web::{get, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, web, App, Error, HttpRequest, HttpResponse, HttpServer, Responder};
+use futures_util::StreamExt as _;
 use crate::metrics::snapshot;
+use actix_ws::{Message, handle};
+use tokio::time::{interval, Duration};
 
 #[get("/metrics")]
 async fn metrics() -> impl Responder {
@@ -10,8 +13,53 @@ async fn metrics() -> impl Responder {
     }
 }
 
+#[get("/ws")]
+pub async fn ws(req: HttpRequest, body: web::Payload) -> Result<HttpResponse, Error> {
+    let (response, mut session, mut stream) = handle(&req, body)?;
+
+    actix_web::rt::spawn(async move {
+        let mut interval = interval(Duration::from_secs(1));
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    match snapshot().await {
+                        Ok(m) => {
+                            if session.text(serde_json::to_string(&m).unwrap()).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            let _ = session.close(None).await;
+                            break;
+                        }
+                    }
+                }
+                msg = stream.next() => {
+                    match msg {
+                        Some(Ok(Message::Ping(bytes))) => {
+                            if session.pong(&bytes).await.is_err() {
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Close(reason))) => {
+                            let _ = session.close(reason).await;
+                            break;
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(_)) | None => {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(response)
+}
+
 pub async fn run() -> std::io::Result<()> {
-    HttpServer::new(|| App::new().service(metrics))
+    HttpServer::new(|| App::new().service(metrics).service(ws))
         .bind(("0.0.0.0", 8080))?
         .run()
         .await

--- a/tests/ws_test.rs
+++ b/tests/ws_test.rs
@@ -1,0 +1,25 @@
+use actix_web::{App};
+use actix_test::start;
+use awc::ws::Frame;
+use futures_util::StreamExt as _;
+use std::time::Duration;
+use tokio::time::timeout;
+
+#[actix_web::test]
+async fn websocket_streams_metrics() {
+    let mut srv = start(|| App::new().service(vpscheck::http::ws));
+    let mut framed = srv.ws_at("/ws").await.expect("connect");
+
+    let frame = timeout(Duration::from_secs(3), framed.next())
+        .await
+        .expect("timed out")
+        .expect("stream closed")
+        .expect("frame error");
+
+    match frame {
+        Frame::Text(bytes) => {
+            let _: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        }
+        other => panic!("unexpected frame: {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- mark the websocket handler public
- add websocket integration test using `actix-test`
- include `actix-test` and `awc` as dev dependencies

## Testing
- `cargo check --color never`
- `cargo test --color never`


------
https://chatgpt.com/codex/tasks/task_e_6851239c0c94832f8fadce615ec69102