### PR TITLE
Refactor project layout and document architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ Connect to `ws://localhost:8080/ws` to receive the same metrics as a JSON string
 This endpoint is useful for dashboards that need live updates.
 
 An integration test in `tests/ws_test.rs` ensures the WebSocket service works correctly.
+
+## Project Structure
+
+```
+src/
+├── main.rs        # binary entry point
+├── lib.rs         # exposes library modules
+├── metrics.rs     # system metric collection
+└── web/
+    ├── mod.rs     # server configuration
+    └── routes.rs  # HTTP and WebSocket handlers
+tests/
+└── ws_test.rs     # integration test
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,2 @@
 pub mod metrics;
-pub mod http;
+pub mod web;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use vpscheck::http;      // ← 库 crate 的名字就是 package name
+use vpscheck::web;      // ← 库 crate 的名字就是 package name
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    http::run().await
+    web::run().await
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,0 +1,15 @@
+use actix_web::{App, HttpServer};
+
+pub mod routes;
+
+pub use routes::{metrics, ws};
+
+pub async fn run() -> std::io::Result<()> {
+    let server = HttpServer::new(|| App::new().service(metrics).service(ws))
+        .bind(("0.0.0.0", 8080))?;
+    for addr in server.addrs() {
+        println!("Web 服务器已启动，监听地址：http://{}", addr);
+        println!("WebSocket 服务器已启动，监听地址：ws://{}", addr);
+    }
+    server.run().await
+}

--- a/tests/ws_test.rs
+++ b/tests/ws_test.rs
@@ -7,7 +7,7 @@ use tokio::time::timeout;
 
 #[actix_web::test]
 async fn websocket_streams_metrics() {
-    let mut srv = start(|| App::new().service(vpscheck::http::ws));
+    let mut srv = start(|| App::new().service(vpscheck::web::ws));
     let mut framed = srv.ws_at("/ws").await.expect("connect");
 
     let frame = timeout(Duration::from_secs(3), framed.next())


### PR DESCRIPTION
## Summary
- move HTTP handlers into `src/web` module
- expose new `web` module from library and update binary entry
- adjust tests to use the new module path
- document the project structure in `README.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859797bdef0832fac5d8f689854e8bf