### PR TITLE
Allow configuring port via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ cargo build --release
 
 ## Running
 
-Launch the server (listens on port `8080` by default):
+Launch the server (listens on port `8080` by default). To use a custom port,
+set the `PORT` environment variable before running:
 
 ```bash
-cargo run --release
+cargo run --release              # uses port 8080
+# PORT=5000 cargo run --release  # custom port example
 ```
 
 ## Querying Metrics
@@ -30,7 +32,8 @@ Requesting `http://localhost:8080/metrics` returns current system statistics in 
 Connect to `ws://localhost:8080/ws` to receive the same metrics as a JSON string every second.
 This endpoint is useful for dashboards that need live updates.
 
-An integration test in `tests/ws_test.rs` ensures the WebSocket service works correctly.
+Integration tests in `tests/ws_test.rs` and `tests/port_test.rs` verify the
+WebSocket endpoint and port configuration respectively.
 
 ## Project Structure
 
@@ -43,5 +46,6 @@ src/
     ├── mod.rs     # server configuration
     └── routes.rs  # HTTP and WebSocket handlers
 tests/
-└── ws_test.rs     # integration test
+├── ws_test.rs     # integration test
+└── port_test.rs   # verifies custom PORT setting
 ```

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4,13 +4,17 @@ pub mod routes;
 
 pub use routes::{metrics, ws};
 
-pub async fn run() -> std::io::Result<()> {
-    let port: u16 = std::env::var("PORT")
+pub fn get_port() -> u16 {
+    std::env::var("PORT")
         .ok()
         .and_then(|p: String| p.parse().ok())
-        .unwrap_or(8080);
-    let server = HttpServer::new(|| App::new().service(metrics).service(ws))
-        .bind(("0.0.0.0", port))?;
+        .unwrap_or(8080)
+}
+
+pub async fn run() -> std::io::Result<()> {
+    let port = get_port();
+    let server =
+        HttpServer::new(|| App::new().service(metrics).service(ws)).bind(("0.0.0.0", port))?;
     for addr in server.addrs() {
         println!("Web 服务器已启动，监听地址：http://{}", addr);
         println!("WebSocket 服务器已启动，监听地址：ws://{}", addr);

--- a/tests/port_test.rs
+++ b/tests/port_test.rs
@@ -1,0 +1,11 @@
+#[test]
+fn env_port_overrides_default() {
+    unsafe {
+        std::env::set_var("PORT", "5555");
+    }
+    assert_eq!(vpscheck::web::get_port(), 5555);
+    unsafe {
+        std::env::remove_var("PORT");
+    }
+    assert_eq!(vpscheck::web::get_port(), 8080);
+}


### PR DESCRIPTION
## Summary
- allow customizing port via `PORT` env var
- document custom port usage in README
- add regression test for port parsing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68598d044b9c832fb2dbbf7823e5fcd0