### PR TITLE
Add distribution name metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo run --release              # uses port 8080
 Requesting `http://localhost:8080/metrics` returns current system statistics in JSON. Example output:
 
 ```json
-{"uptime_days":0,"load":[1.49,0.44,0.15],"cpu":0.19,"mem_used":"471.64 MiB","mem_total":"9.93 GiB","disk_used_gib":13.52,"disk_total_gib":62.44,"rx_rate":0,"tx_rate":0,"rx_total_gib":0.0166,"tx_total_gib":0.00014,"swap_used_mib":0.0,"swap_total_mib":0.0,"tcp":7,"udp":2,"processes":15,"threads":24}
+{"os_name":"Ubuntu","uptime_days":0,"load":[1.49,0.44,0.15],"cpu":0.19,"mem_used":"471.64 MiB","mem_total":"9.93 GiB","disk_used_gib":13.52,"disk_total_gib":62.44,"rx_rate":0,"tx_rate":0,"rx_total_gib":0.0166,"tx_total_gib":0.00014,"swap_used_mib":0.0,"swap_total_mib":0.0,"tcp":7,"udp":2,"processes":15,"threads":24}
 ```
 
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,14 +1,31 @@
-use std::time::Duration;
 use anyhow::Result;
 use procfs::net;
+use std::time::Duration;
 use sysinfo::{Disks, LoadAvg, NetworkData, Networks, System};
-use tokio::time::sleep;                 // 替换 thread::sleep
+use tokio::time::sleep; // 替换 thread::sleep
 
 const BYTES_PER_MIB: f64 = 1_048_576.0;
 const BYTES_PER_GIB: f64 = 1_073_741_824.0;
 
+fn os_name() -> String {
+    std::fs::read_to_string("/etc/os-release")
+        .ok()
+        .and_then(|content| {
+            for line in content.lines() {
+                if let Some(v) = line.strip_prefix("PRETTY_NAME=") {
+                    return Some(v.trim_matches('"').to_string());
+                } else if let Some(v) = line.strip_prefix("NAME=") {
+                    return Some(v.trim_matches('"').to_string());
+                }
+            }
+            None
+        })
+        .unwrap_or_else(|| "Unknown".into())
+}
+
 #[derive(serde::Serialize)]
 pub struct Metrics {
+    pub os_name: String,
     pub uptime_days: u64,
     pub load: (f64, f64, f64),
     pub cpu: f32,
@@ -44,8 +61,8 @@ fn fmt(bytes: u64) -> String {
 
 /// 一次性快照；耗时 1 s 用于计算网速。
 pub async fn snapshot() -> Result<Metrics> {
-    let mut sys   = System::new_all();
-    let mut nets  = Networks::new_with_refreshed_list();
+    let mut sys = System::new_all();
+    let mut nets = Networks::new_with_refreshed_list();
     let mut disks = Disks::new_with_refreshed_list();
 
     sys.refresh_cpu_usage();
@@ -63,16 +80,22 @@ pub async fn snapshot() -> Result<Metrics> {
     let uptime_days = System::uptime() / 86_400;
     let LoadAvg { one, five, fifteen } = System::load_average();
 
-    let mem_used  = sys.used_memory();
+    let mem_used = sys.used_memory();
     let mem_total = sys.total_memory();
-    let swap_used  = sys.used_swap();
+    let swap_used = sys.used_swap();
     let swap_total = sys.total_swap();
 
-    let disk_used: u64  = disks.list().iter().map(|d| d.total_space() - d.available_space()).sum();
+    let disk_used: u64 = disks
+        .list()
+        .iter()
+        .map(|d| d.total_space() - d.available_space())
+        .sum();
     let disk_total: u64 = disks.list().iter().map(|d| d.total_space()).sum();
 
-    let proc_cnt   = sys.processes().len();
-    let thread_cnt = sys.processes().values()
+    let proc_cnt = sys.processes().len();
+    let thread_cnt = sys
+        .processes()
+        .values()
         .map(|p| p.tasks().map_or(1, |set| set.len() + 1))
         .sum::<usize>();
 
@@ -80,19 +103,20 @@ pub async fn snapshot() -> Result<Metrics> {
     let udp = net::udp()?.len() + net::udp6()?.len();
 
     Ok(Metrics {
+        os_name: os_name(),
         uptime_days,
         load: (one, five, fifteen),
         cpu: sys.global_cpu_usage(),
         mem_used: fmt(mem_used),
         mem_total: fmt(mem_total),
-        disk_used_gib:  disk_used  as f64 / BYTES_PER_GIB,
+        disk_used_gib: disk_used as f64 / BYTES_PER_GIB,
         disk_total_gib: disk_total as f64 / BYTES_PER_GIB,
         // saturating_sub handles counter wrap
         rx_rate: rx1.saturating_sub(rx0),
         tx_rate: tx1.saturating_sub(tx0),
         rx_total_gib: rx1 as f64 / BYTES_PER_GIB,
         tx_total_gib: tx1 as f64 / BYTES_PER_GIB,
-        swap_used_mib:  swap_used  as f64 / BYTES_PER_MIB,
+        swap_used_mib: swap_used as f64 / BYTES_PER_MIB,
         swap_total_mib: swap_total as f64 / BYTES_PER_MIB,
         tcp,
         udp,


### PR DESCRIPTION
## Summary
- add helper to detect distro name from `/etc/os-release`
- include new `os_name` field in metrics output
- show `os_name` in README JSON example

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685fcbcb880c832fa5a047a92b3526cf